### PR TITLE
Death in non overworld bugfix

### DIFF
--- a/src/main/java/ru/nukkitx/Dimensions.java
+++ b/src/main/java/ru/nukkitx/Dimensions.java
@@ -7,6 +7,8 @@ import cn.nukkit.event.EventHandler;
 import cn.nukkit.event.EventPriority;
 import cn.nukkit.event.Listener;
 import cn.nukkit.event.entity.EntityLevelChangeEvent;
+import cn.nukkit.event.player.PlayerDeathEvent;
+import cn.nukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import cn.nukkit.event.server.DataPacketSendEvent;
 import cn.nukkit.network.protocol.ChangeDimensionPacket;
 import cn.nukkit.network.protocol.DataPacket;
@@ -20,7 +22,7 @@ public class Dimensions extends PluginBase implements Listener {
         Server.getInstance().getPluginManager().registerEvents(this, this);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onDataPacketSend(DataPacketSendEvent event) {
         DataPacket packet = event.getPacket();
         Player player = event.getPlayer();
@@ -30,8 +32,14 @@ public class Dimensions extends PluginBase implements Listener {
             startGamePacket.dimension = (byte) player.getLevel().getDimension();
         }
     }
+    
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        player.teleport(player.getSpawn(), TeleportCause.PLUGIN);
+    }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onLevelChange(EntityLevelChangeEvent event) {
         Entity entity = event.getEntity();
 

--- a/src/main/java/ru/nukkitx/Dimensions.java
+++ b/src/main/java/ru/nukkitx/Dimensions.java
@@ -10,7 +10,9 @@ import cn.nukkit.event.entity.EntityLevelChangeEvent;
 import cn.nukkit.event.player.PlayerDeathEvent;
 import cn.nukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import cn.nukkit.event.server.DataPacketSendEvent;
+import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
+import cn.nukkit.level.Location;
 import cn.nukkit.network.protocol.ChangeDimensionPacket;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.network.protocol.PlayStatusPacket;
@@ -38,6 +40,15 @@ public class Dimensions extends PluginBase implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
     	if(event.getEntity().getLocation().getLevel().getDimension() != Level.DIMENSION_OVERWORLD) {
     		 Player player = event.getEntity();
+    		 Location location = player.getLocation();
+    		 Item[] drops = event.getDrops();
+    		 int xp = event.getExperience();
+    		 location.getLevel().dropExpOrb(location, xp);
+    		 for(Item drop : drops) {
+    			 location.getLevel().dropItem(location, drop);
+    		 }
+    		 event.setDrops(new Item[0]);
+    		 event.setExperience(0);
     	     player.teleport(player.getSpawn(), TeleportCause.PLUGIN);
     	}       
     }

--- a/src/main/java/ru/nukkitx/Dimensions.java
+++ b/src/main/java/ru/nukkitx/Dimensions.java
@@ -10,6 +10,7 @@ import cn.nukkit.event.entity.EntityLevelChangeEvent;
 import cn.nukkit.event.player.PlayerDeathEvent;
 import cn.nukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import cn.nukkit.event.server.DataPacketSendEvent;
+import cn.nukkit.level.Level;
 import cn.nukkit.network.protocol.ChangeDimensionPacket;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.network.protocol.PlayStatusPacket;
@@ -35,8 +36,10 @@ public class Dimensions extends PluginBase implements Listener {
     
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerDeath(PlayerDeathEvent event) {
-        Player player = event.getEntity();
-        player.teleport(player.getSpawn(), TeleportCause.PLUGIN);
+    	if(event.getEntity().getLocation().getLevel().getDimension() != Level.DIMENSION_OVERWORLD) {
+    		 Player player = event.getEntity();
+    	     player.teleport(player.getSpawn(), TeleportCause.PLUGIN);
+    	}       
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)


### PR DESCRIPTION
added event listener for player death, to teleport them back to their spawn allowing them to press the respawn button.